### PR TITLE
Adding ci-operator file

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.18


### PR DESCRIPTION
`buildRootImageStream from repository: failed to read .ci-operator.yaml file: open ./.ci-operator.yaml: no such file or directory}`

https://github.com/openshift/release/pull/52792