### PR TITLE
Use oc for calls

### DIFF
--- a/dast/results.sh
+++ b/dast/results.sh
@@ -43,8 +43,8 @@ spec:
         claimName: $PVC
 EOF
 
-kubectl apply -f $TMP_DIR/$RANDOM_NAME
+oc apply -f $TMP_DIR/$RANDOM_NAME
 rm $TMP_DIR/$RANDOM_NAME
-kubectl wait --for=condition=Ready pod/$RANDOM_NAME
-kubectl cp $RANDOM_NAME:/opt/rapidast/results $RESULTS_DIR
-kubectl delete pod $RANDOM_NAME
+oc wait --for=condition=Ready pod/$RANDOM_NAME
+oc cp $RANDOM_NAME:/opt/rapidast/results $RESULTS_DIR
+oc delete pod $RANDOM_NAME


### PR DESCRIPTION
`./results.sh: line 50: kubectl: command not found`
https://github.com/openshift/release/pull/54720

Want to focus on oc calls since we are testing openshift here
